### PR TITLE
feat: Add static About, FAQ, and Contact pages

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -205,5 +205,23 @@ def profile_page():
                            reviews=user_reviews_list 
                            )
 
+@main_bp.route('/about')
+def about_page():
+    """Renders the About Us page."""
+    logger.info("Route: About Us page requested.")
+    return render_template('about.html')
+
+@main_bp.route('/faq')
+def faq_page():
+    """Renders the FAQ page."""
+    logger.info("Route: FAQ page requested.")
+    return render_template('faq.html')
+
+@main_bp.route('/contact')
+def contact_page():
+    """Renders the Contact Us page."""
+    logger.info("Route: Contact Us page requested.")
+    return render_template('contact.html')
+
 # Removed old /admin-dashboard and /employee-dashboard routes from main_bp.
 # These will now be handled by their own dedicated blueprints (e.g., app.admin).

--- a/app/templates/about.html
+++ b/app/templates/about.html
@@ -1,0 +1,50 @@
+{# /app/templates/about.html #}
+{% extends "base.html" %}
+
+{% block title %}About Us - BookNook{% endblock %}
+
+{% block content %}
+<div class="container mt-4 mb-5">
+    <div class="text-center border-bottom pb-4 mb-4">
+        <h1 class="display-4">About Atomic's BookNook</h1>
+        <p class="lead">Discover Your Next Chapter, With Us.</p>
+    </div>
+
+    <div class="row g-5 align-items-center">
+        <div class="col-md-6">
+            <h2>Our Story</h2>
+            <p>Founded in 2024 by two passionate Computer Science students from Colorado Technical University, BookNook was born from a shared love for literature and technology. We believe that discovering a new book should be an adventure, and our mission is to create a seamless and enjoyable online bookstore experience for readers everywhere.</p>
+            <p>Our project started as a final assignment for CS492, but quickly grew into a passion project. We've poured our knowledge of software development, database management, and user-centric design into creating a platform that is both robust and easy to use. We are dedicated to the principles of continuous improvement and are always looking for ways to make BookNook better for our community of readers.</p>
+        </div>
+        <div class="col-md-6 text-center">
+            <img src="{{ url_for('static', filename='images/atomic_logo.ico') }}" alt="BookNook Logo" class="img-fluid rounded-circle shadow-sm" style="max-width: 250px;">
+        </div>
+    </div>
+
+    <hr class="my-5">
+
+    <div class="text-center">
+        <h2 class="mb-4">Meet the Team</h2>
+    </div>
+
+    <div class="row text-center justify-content-center">
+        <div class="col-lg-4 col-md-6 mb-4">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body p-4">
+                    <h5 class="card-title mb-1">Reginald Cosens III</h5>
+                    <p class="card-text text-muted">Frontend & Backend Developer</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-4 col-md-6 mb-4">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body p-4">
+                    <h5 class="card-title mb-1">Edwin Zacarias</h5>
+                    <p class="card-text text-muted">Project Manager & QA Systems Engineer</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+</div>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,10 +5,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}BookNook{% endblock %} - Your Next Chapter</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" xintegrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
-    {# Assuming atomic_logo.ico is in app/static/images/ based on your previous atomic_logo.svg path #}
-    {# If atomic_logo.ico is directly in app/static/, change filename to 'atomic_logo.ico' #}
     <link rel="icon" href="{{ url_for('static', filename='images/atomic_logo.ico') }}" type="image/x-icon"> 
     {% block head_extra %}{% endblock %}
 </head>
@@ -18,9 +16,6 @@
         <nav class="navbar navbar-expand-lg navbar-dark">
             <div class="container">
                 <a class="navbar-brand d-flex align-items-center" href="{{ url_for('main.home') }}">
-                    {# YOUR EMBEDDED SVG LOGO - Preserved #}
-                    {# If you decide to use an external SVG file later, you can change this to an <img> tag #}
-                    {# For example: <img src="{{ url_for('static', filename='images/atomic_logo.svg') }}" alt="BookNook Logo" width="90" height="90" class="me-2"> #}
                     <svg width="90" height="90" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" class="me-2">
                         <defs>
                             <linearGradient id="quantumGradient" x1="0%" y1="0%" x2="100%" y2="100%">
@@ -52,14 +47,14 @@
                         <li class="nav-item">
                             <a class="nav-link {% if request.endpoint == 'main.home' %}active fw-bold{% endif %}" href="{{ url_for('main.home') }}">Home</a>
                         </li>
-                        <li class="nav-item {% if not current_user.is_authenticated %}me-3{% else %}me-2{% endif %}"> {# Conditional margin based on auth state #}
+                        <li class="nav-item {% if not current_user.is_authenticated %}me-3{% else %}me-2{% endif %}">
                             <a class="nav-link position-relative {% if request.endpoint == 'cart.view_cart_route' %}active fw-bold{% endif %}" href="{{ url_for('cart.view_cart_route') }}">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-cart3 me-1" viewBox="0 0 16 16">
                                     <path d="M0 1.5A.5.5 0 0 1 .5 1H2a.5.5 0 0 1 .485.379L2.89 3H14.5a.5.5 0 0 1 .49.598l-1 5a.5.5 0 0 1-.465.401l-9.397.472L4.744 11.5H13a.5.5 0 0 1 0 1H4a.5.5 0 0 1-.491-.408L2.01 3.607 1.61 2H.5a.5.5 0 0 1-.5-.5zM3.102 4l.84 4.479 9.144-.459L13.89 4H3.102zM5 12a2 2 0 1 0 0 4 2 2 0 0 0 0-4zm7 0a2 2 0 1 0 0 4 2 2 0 0 0 0-4zm-7 1a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm7 1a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>
                                 </svg>
                                 Cart
                                 <span id="cart-item-count-badge-navbar" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" style="font-size: 0.65em; display: none;">
-                                    0 {# Initial value, will be updated by JS #}
+                                    0
                                 </span>
                             </a>
                         </li>
@@ -74,9 +69,9 @@
                                 </a>
                                 <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarUserDropdown">
                                     <li><a class="dropdown-item" href="{{ url_for('main.profile_page') }}">My Profile</a></li>
-                                    {% if current_user.is_admin() %} {# Simplified check, assuming User model has is_admin() #}
+                                    {% if current_user.is_admin() %}
                                         <li><a class="dropdown-item" href="{{ url_for('admin.dashboard') }}">Admin Dashboard</a></li>
-                                    {% elif current_user.is_employee() %}  {# Assuming User model has is_employee() #}
+                                    {% elif current_user.is_employee() %}
                                          <li><a class="dropdown-item disabled" href="#">Employee Dashboard (Soon)</a></li>
                                     {% endif %}
                                     <li><hr class="dropdown-divider"></li>
@@ -84,7 +79,6 @@
                                 </ul>
                             </li>
                         {% else %}
-                            {# Your conditional logic for showing login/register or not #}
                             {% if show_nav is not defined or show_nav %} 
                             <li class="nav-item">
                                 <a href="{{ url_for('auth.login', next=request.full_path if request.endpoint not in ['auth.login', 'auth.register'] else None) }}" class="btn btn-outline-light btn-sm me-2">Login</a>
@@ -123,7 +117,6 @@
 
     <footer class="footer mt-auto py-3 bg-dark text-light border-top">
         <div class="container text-center">
-            {# ... (Your existing footer content from message #87) ... #}
              <div class="row align-items-center">
                 <div class="col-md-4 mb-3 mb-md-0 text-md-start">
                     <h5>BookNook</h5>
@@ -132,9 +125,9 @@
                 <div class="col-md-4 mb-3 mb-md-0">
                     <ul class="list-inline mb-0">
                         <li class="list-inline-item"><a href="{{ url_for('main.home') }}" class="text-white-50 text-decoration-none">Home</a></li>
-                        <li class="list-inline-item"><a href="#" class="text-white-50 text-decoration-none">About</a></li>
-                        <li class="list-inline-item"><a href="#" class="text-white-50 text-decoration-none">Contact</a></li>
-                        <li class="list-inline-item"><a href="#" class="text-white-50 text-decoration-none">FAQ</a></li>
+                        <li class="list-inline-item"><a href="{{ url_for('main.about_page') }}" class="text-white-50 text-decoration-none">About</a></li>
+                        <li class="list-inline-item"><a href="{{ url_for('main.contact_page') }}" class="text-white-50 text-decoration-none">Contact</a></li>
+                        <li class="list-inline-item"><a href="{{ url_for('main.faq_page') }}" class="text-white-50 text-decoration-none">FAQ</a></li>
                     </ul>
                 </div>
                 <div class="col-md-4 text-md-end">
@@ -152,39 +145,20 @@
         </div>
     </footer>
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" xintegrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
     
-    {# *** ADDED/MODIFIED SCRIPT BLOCK for initial data *** #}
     <script>
-        // Make current_user.id available to JavaScript if user is authenticated, otherwise null.
         window.currentUserId = {{ current_user.id|tojson if current_user.is_authenticated else 'null' }};
-        
-        // Make initial cart item count available to JavaScript for navbar badge initialization.
-        // This 'navbar_cart_item_count' variable is injected by the context processor in app/__init__.py.
         window.initialCartData = {
             itemCount: {{ navbar_cart_item_count | default(0) }}
-            // If you were also passing the cart total string from the context processor:
-            // cartTotalStr: "{{ navbar_cart_total_str | default('0.00') }}"
         };
-
-        // If your home.html/customer.html pages pass a booksData object (for modals):
-        // This needs to be defined on pages where `books_data_for_js` is passed to the template.
-        // {% if books_data_for_js is defined %}
-        // window.booksData = {{ books_data_for_js | tojson | safe }};
-        // {% else %}
-        // window.booksData = {}; // Define as empty object if not passed, to avoid JS errors
-        // {% endif %}
     </script>
 
     <script src="{{ url_for('static', filename='js/utils.js') }}" defer></script> 
     <script src="{{ url_for('static', filename='js/navbar_cart_updater.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/cart_handler.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/review_handler.js') }}" defer></script>
-    {# The old submit_review.js functionality should now be in review_handler.js #}
-    {# Ensure it's removed or its content merged and the old file deleted from static/js #}
-    {# <script src="{{ url_for('static', filename='js/submit_review.js') }}" defer></script> #}
 
-    {# Block for page-specific JavaScript files or inline scripts #}
     {% block scripts %}{% endblock %} 
 </body>
 </html>

--- a/app/templates/contact.html
+++ b/app/templates/contact.html
@@ -1,0 +1,60 @@
+{# /app/templates/contact.html #}
+{% extends "base.html" %}
+
+{% block title %}Contact Us - BookNook{% endblock %}
+
+{% block content %}
+<div class="container mt-4 mb-5">
+    <div class="text-center border-bottom pb-4 mb-5">
+        <h1 class="display-4">Get In Touch</h1>
+        <p class="lead">We'd love to hear from you. Whether you have a question about features, trials, pricing, or anything else, our team is ready to answer all your questions.</p>
+    </div>
+
+    <div class="row g-5">
+        <div class="col-md-6">
+            <h4 class="mb-3">Contact Information</h4>
+            <p>
+                <strong>BookNook Headquarters</strong><br>
+                123 Knowledge Lane<br>
+                Hagerstown, MD 21740<br>
+                United States
+            </p>
+            <p>
+                <strong>Email:</strong> <a href="mailto:support@booknook.example.com">support@booknook.example.com</a><br>
+                <strong>Phone:</strong> <a href="tel:+1234567890">(123) 456-7890</a>
+            </p>
+            <h5 class="mt-4">Business Hours</h5>
+            <p>
+                Monday - Friday: 9:00 AM - 6:00 PM (EST)<br>
+                Saturday - Sunday: Closed
+            </p>
+            <!-- Embedded Google Map -->
+            <div class="mt-4 shadow-sm">
+                <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d98932.39899387607!2d-77.80497519395777!3d39.63583271849969!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89c9ef3b6038c539%3A0x454431f41398579!2sHagerstown%2C%20MD!5e0!3m2!1sen!2sus!4v1717799539316!5m2!1sen!2sus" width="100%" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <h4 class="mb-3">Send Us a Message</h4>
+            <form action="#" method="POST"> {# This form is a visual placeholder #}
+                <div class="mb-3">
+                    <label for="contactName" class="form-label">Your Name</label>
+                    <input type="text" class="form-control" id="contactName" required>
+                </div>
+                <div class="mb-3">
+                    <label for="contactEmail" class="form-label">Your Email</label>
+                    <input type="email" class="form-control" id="contactEmail" required>
+                </div>
+                 <div class="mb-3">
+                    <label for="contactSubject" class="form-label">Subject</label>
+                    <input type="text" class="form-control" id="contactSubject" required>
+                </div>
+                <div class="mb-3">
+                    <label for="contactMessage" class="form-label">Message</label>
+                    <textarea class="form-control" id="contactMessage" rows="5" required></textarea>
+                </div>
+                <button type="submit" class="btn btn-primary w-100 disabled">Submit (Feature Coming Soon)</button>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/faq.html
+++ b/app/templates/faq.html
@@ -1,0 +1,209 @@
+{% extends "base.html" %}
+
+{% block title %}Frequently Asked Questions - Atomics BookNook{% endblock %}
+
+{% block content %}
+<div class="container mt-4 mb-5">
+    <h1 class="mb-4 text-center display-5">Frequently Asked Questions</h1>
+
+    <div class="card shadow-sm p-4">
+        <p class="lead">Welcome to our FAQ section! We've compiled a list of common questions to help you find answers quickly. If you can't find what you're looking for here, please don't hesitate to <a href="{{ url_for('main.contact_page') }}" class="alert-link">contact us</a>.</p>
+
+        <div class="accordion accordion-flush" id="faqAccordion">
+
+            <h3 class="mt-4 pt-3 border-top">Ordering & Accounts</h3>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingOne">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
+                        1. How do I create an account?
+                    </button>
+                </h2>
+                <div id="collapseOne" class="accordion-collapse collapse" aria-labelledby="headingOne" data-bs-parent="#faqAccordion">
+                    <div class="accordion-body">
+                        Click on the "Sign Up" or "Register" link in the top right corner of our homepage. Follow the prompts to enter your details and create your Atomics BookNook account.
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingTwo">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
+                        2. Do I need an account to place an order?
+                    </button>
+                </h2>
+                <div id="collapseTwo" class="accordion-collapse collapse" aria-labelledby="headingTwo" data-bs-parent="#faqAccordion">
+                    <div class="accordion-body">
+                        No, you can check out as a guest. However, creating an account allows you to track your orders, view your order history, save your shipping information for faster checkout, and receive personalized recommendations.
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingThree">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
+                        3. How do I place an order?
+                    </button>
+                </h2>
+                <div id="collapseThree" class="accordion-collapse collapse" aria-labelledby="headingThree" data-bs-parent="#faqAccordion">
+                    <div class="accordion-body">
+                        Browse our selection, add desired books to your cart, and proceed to checkout. Follow the on-screen instructions to enter your shipping and payment information.
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingFour">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFour" aria-expanded="false" aria-controls="collapseFour">
+                        4. How can I track my order?
+                    </button>
+                </h2>
+                <div id="collapseFour" class="accordion-collapse collapse" aria-labelledby="headingFour" data-bs-parent="#faqAccordion">
+                    <div class="accordion-body">
+                        If you have an account, log in and navigate to your "Order History" under "My Profile". If you checked out as a guest, you will receive an order confirmation email with a tracking link once your order has shipped.
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingFive">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFive" aria-expanded="false" aria-controls="collapseFive">
+                        5. Can I modify or cancel my order after it's been placed?
+                    </button>
+                </h2>
+                <div id="collapseFive" class="accordion-collapse collapse" aria-labelledby="headingFive" data-bs-parent="#faqAccordion">
+                    <div class="accordion-body">
+                        We process orders quickly. If you need to modify or cancel an order, please contact us immediately at <a href="mailto:orders@atomicsbooknook.com">orders@atomicsbooknook.com</a>. We will do our best to accommodate your request, but we cannot guarantee changes once an order has entered the shipping process.
+                    </div>
+                </div>
+            </div>
+
+            <h3 class="mt-4 pt-3 border-top">Shipping & Delivery</h3>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingSix">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseSix" aria-expanded="false" aria-controls="collapseSix">
+                        6. What shipping options do you offer?
+                    </button>
+                </h2>
+                <div id="collapseSix" class="accordion-collapse collapse" aria-labelledby="headingSix" data-bs-parent="#faqAccordion">
+                    <div class="accordion-body">
+                        We offer various shipping options including standard, expedited, and express delivery. Shipping costs and estimated delivery times will be calculated at checkout based on your location and chosen shipping method.
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingSeven">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseSeven" aria-expanded="false" aria-controls="collapseSeven">
+                        7. Do you ship internationally?
+                    </button>
+                </h2>
+                <div id="collapseSeven" class="accordion-collapse collapse" aria-labelledby="headingSeven" data-bs-parent="#faqAccordion">
+                    <div class="accordion-body">
+                        Yes, Atomics BookNook ships to many international destinations. International shipping costs and delivery times vary. Please enter your address at checkout to see if we ship to your location and to calculate the shipping cost.
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingEight">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseEight" aria-expanded="false" aria-controls="collapseEight">
+                        8. How long does shipping take?
+                    </button>
+                </h2>
+                <div id="collapseEight" class="accordion-collapse collapse" aria-labelledby="headingEight" data-bs-parent="#faqAccordion">
+                    <div class="accordion-body">
+                        Domestic standard shipping typically takes 5-7 business days. Expedited and express options are faster. International shipping can take 7-21 business days depending on the destination and customs. Please note these are estimates and can vary.
+                    </div>
+                </div>
+            </div>
+
+            <h3 class="mt-4 pt-3 border-top">Returns & Refunds</h3>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingNine">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseNine" aria-expanded="false" aria-controls="collapseNine">
+                        9. What is your return policy?
+                    </button>
+                </h2>
+                <div id="collapseNine" class="accordion-collapse collapse" aria-labelledby="headingNine" data-bs-parent="#faqAccordion">
+                    <div class="accordion-body">
+                        We accept returns of new, unopened books within 30 days of delivery. The item must be in its original condition. Please see our full <a href="#" class="alert-link" disabled>Returns Policy page (Theoretical Link)</a> for complete details and instructions on how to initiate a return.
+                        {# You would replace the '#' with a url_for to your actual returns policy page if implemented.
+                           e.g., <a href="{{ url_for('main.returns_policy_route') }}" class="alert-link">Returns Policy page</a> #}
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingTen">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTen" aria-expanded="false" aria-controls="collapseTen">
+                        10. How do I return an item?
+                    </button>
+                </h2>
+                <div id="collapseTen" class="accordion-collapse collapse" aria-labelledby="headingTen" data-bs-parent="#faqAccordion">
+                    <div class="accordion-body">
+                        Please contact <a href="mailto:support@atomicsbooknook.com">support@atomicsbooknook.com</a> to initiate a return. We will provide you with instructions and a return shipping label if applicable.
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingEleven">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseEleven" aria-expanded="false" aria-controls="collapseEleven">
+                        11. When will I receive my refund?
+                    </button>
+                </h2>
+                <div id="collapseEleven" class="accordion-collapse collapse" aria-labelledby="headingEleven" data-bs-parent="#faqAccordion">
+                    <div class="accordion-body">
+                        Once we receive and inspect your returned item, your refund will be processed to your original payment method within 5-7 business days. Shipping charges are non-refundable unless the return is due to our error.
+                    </div>
+                </div>
+            </div>
+
+            <h3 class="mt-4 pt-3 border-top">Payments & Security</h3>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingTwelve">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTwelve" aria-expanded="false" aria-controls="collapseTwelve">
+                        12. What payment methods do you accept?
+                    </button>
+                </h2>
+                <div id="collapseTwelve" class="accordion-collapse collapse" aria-labelledby="headingTwelve" data-bs-parent="#faqAccordion">
+                    <div class="accordion-body">
+                        We accept major credit cards (Visa, MasterCard, American Express, Discover), PayPal, and other popular digital payment options. (Adjust this to match your actual payment gateway integrations if any).
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingThirteen">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseThirteen" aria-expanded="false" aria-controls="collapseThirteen">
+                        13. Is my payment information secure?
+                    </button>
+                </h2>
+                <div id="collapseThirteen" class="accordion-collapse collapse" aria-labelledby="headingThirteen" data-bs-parent="#faqAccordion">
+                    <div class="accordion-body">
+                        Yes, absolutely. Atomics BookNook uses industry-standard SSL encryption to protect your personal and payment information during all transactions. We do not store your credit card details on our servers.
+                    </div>
+                </div>
+            </div>
+
+            <h3 class="mt-4 pt-3 border-top">Other Questions</h3>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingFourteen">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFourteen" aria-expanded="false" aria-controls="collapseFourteen">
+                        14. Do you offer gift cards?
+                    </button>
+                </h2>
+                <div id="collapseFourteen" class="accordion-collapse collapse" aria-labelledby="headingFourteen" data-bs-parent="#faqAccordion">
+                    <div class="accordion-body">
+                        Yes, Atomics BookNook gift cards are available for purchase in various denominations. They are the perfect gift for any book lover!
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingFifteen">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFifteen" aria-expanded="false" aria-controls="collapseFifteen">
+                        15. How can I stay updated on new releases and promotions?
+                    </button>
+                </h2>
+                <div id="collapseFifteen" class="accordion-collapse collapse" aria-labelledby="headingFifteen" data-bs-parent="#faqAccordion">
+                    <div class="accordion-body">
+                        Sign up for our newsletter at the bottom of our homepage! You can also follow us on our social media channels.
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Purpose
This pull request introduces three static informational pages (About, FAQ, Contact Us) and activates the corresponding links in the site-wide footer. The primary goal is to enhance the application's completeness and provide a more professional user experience for the upcoming project demo.

Summary of Changes
New Templates: Created three new HTML templates in app/templates/:

about.html: Contains a team bio and project story.

faq.html: An accordion-style FAQ section addressing common user questions.

contact.html: Provides contact information, business hours, and an embedded map.

New Routes: Added three corresponding routes (/about, /faq, /contact) to app/main/routes.py to render the new templates.

Footer Update: Modified app/templates/base.html to update the href attributes in the footer, pointing them to the new routes using url_for().

How to Test
Run the application locally.

Navigate to the footer section on any page.

Click the "About" link and verify that the "About Us" page loads correctly.

Click the "FAQ" link and verify that the "Frequently Asked Questions" page loads and the accordion functions.

Click the "Contact" link and verify that the "Contact Us" page loads with all details.